### PR TITLE
chore(release): prepare v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes relevant to users, reviewers, or distribution are documented in this file.
+
+This project follows Semantic Versioning.
+
+## v1.2.0 - 2026-03-23
+
+### Added
+- Support for Terragrunt configuration execution inside the shell.
+
+### Changed
+- Streamlined output configuration headers, shifting from `## Section: Name` to `## Name`.
+
+### Fixed
+- Error redirection to `/dev/null` for `rosa` completion to silence missing CLI outputs.
+- Corrected `.local/bin/env` evaluation path for `nvm` initialization.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 SHELL := /bin/bash
 PROJECT_NAME := myshell_rfd-$(VERSION)
-VERSION := v1.1.0
+VERSION := v1.2.0
 BUILD_DIR := dist
 SRC_DIR := src
 TEST_DIR := tests


### PR DESCRIPTION
## Objective
Prepare release v1.2.0 with the latest terragrunt module feature and fixes.

## Type of change
release

## Impact
`CHANGELOG.md` created
`Makefile` version bumped

## Validation
Reviewed changelog notes against merged feature branches.

## Checklist
- [x] Build passes
- [ ] Tests updated or justification provided
- [ ] Documentation updated if applicable
- [ ] Breaking changes documented if applicable