### PR TITLE
fix(terraform): use dynamic path for completion binary

### DIFF
--- a/src/modules/terraform.sh
+++ b/src/modules/terraform.sh
@@ -11,7 +11,7 @@ configure_terraform() {
         if prompt_yes_no "Enable Terraform autocompletion and aliases?" "y"; then
             read -r -d '' config_content << EOM
 autoload -U +X bashcompinit && bashcompinit
-complete -o nospace -C /usr/local/bin/terraform terraform
+complete -o nospace -C terraform terraform
 alias t='terraform'
 alias ti='terraform init'
 alias tp='terraform plan'


### PR DESCRIPTION
## Objective
Fix terraform completion by using the binary name instead of a hardcoded path.

## Type of change
fix

## Impact
`src/modules/terraform.sh`

## Validation
Visual inspection of the change.

## Checklist
- [x] Build passes
- [ ] Tests updated
- [ ] Documentation updated